### PR TITLE
Use docker from docker.io; lock to specific version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,13 @@ FROM centos:7
 
 ENV TERRAFORM_VERSION=0.7.7
 ENV TERRAGRUNT_VERSION=v0.1.2
+ENV DOCKER_VERSION=1.12.3-1.el7.centos
 
-RUN rpm -iUvh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-8.noarch.rpm
-RUN yum install -y bash ca-certificates curl docker gawk git git openssl python-pip unzip wget
+ADD yum.repos.d/docker.repo /etc/yum.repos.d/
 
-RUN cd /tmp && \
+RUN rpm -iUvh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-8.noarch.rpm && \
+    yum install -y bash ca-certificates curl docker-engine-${DOCKER_VERSION} gawk git git openssl python-pip unzip wget && \
+    cd /tmp && \
     curl -sSLO https://github.com/gruntwork-io/terragrunt/releases/download/${TERRAGRUNT_VERSION}/terragrunt_linux_amd64 && \
     mv terragrunt_linux_amd64 /usr/local/bin/terragrunt && \
     curl -sSLO https://releases.hashicorp.com/terraform/$TERRAFORM_VERSION/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \

--- a/yum.repos.d/docker.repo
+++ b/yum.repos.d/docker.repo
@@ -1,0 +1,6 @@
+[dockerrepo]
+name=Docker Repository
+baseurl=https://yum.dockerproject.org/repo/main/centos/7/
+enabled=1
+gpgcheck=1
+gpgkey=https://yum.dockerproject.org/gpg


### PR DESCRIPTION
This is so we can run latest Docker version; old one - from Yum repo started
causing issues