### PR TITLE
BREAKS BACKWARDS COMPATABILITY!:  Move to using terraform native s3 state handling, as needed to update terraform to newer version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM centos:7
 
-ENV TERRAFORM_VERSION=0.8.8
+ENV TERRAFORM_VERSION=0.9.8
 ENV TERRAGRUNT_VERSION=v0.6.0
 ENV DOCKER_COMPOSE_VERSION=1.9.0
 
@@ -24,5 +24,7 @@ RUN yum install -y epel-release && \
     curl -L "https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_VERSION/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose && \
     yum group remove "Development Tools" -y && yum clean all
+
+
 
 ADD . /infra


### PR DESCRIPTION
Also allow pass an option state_aws_region for s3 state

Continuation of the change done previously which breaks backwards compatibility.

When deploying a project in multiple regions, this code would use the same
bucket located in eu-west-1 for all of them. This would mean that terraform
would fail accessing the bucket when using the region eu-west-1 with an
error like:

    Error loading state: AuthorizationHeaderMalformed: The authorization
    header is malformed; the region 'us-east-1' is wrong; expecting
    'eu-west-1'
    status code: 400, request id: 786C67FDB3FCDE5A, host id:
    6+ZFE4vSlyJRvr6+nzIV6lXlgTT2Y3rtGNcSOAKHgoE4+T4y4g/u9jaU7/1SlMKK81E0YvnAeas=

Fixing this issue will take time, and it requires refactoring all the
setup. Instead, I will sadly and regretfully kick the can down the road and
fix this.

The solution can be add an optional argument called:

    var state_aws_region=...

that will define which region is the state stored.